### PR TITLE
Fixed usage on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ func main() {
 	defer client.Close()
 
 	// Obtain a new lock with default settings
-	lock, err := lock.ObtainLock(client, "lock.foo", nil)
+	lock, err := lock.Obtain(client, "lock.foo", nil)
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())
 		return


### PR DESCRIPTION
Current method is not ObtainLock() but Obtain().
So I've fixed README.