### PR TITLE
Adding getToken and getLocker methods

### DIFF
--- a/lock.go
+++ b/lock.go
@@ -215,3 +215,24 @@ func randomToken() (string, error) {
 	}
 	return base64.URLEncoding.EncodeToString(buf), nil
 }
+
+func (l *Locker) GetToken() string {
+	return l.token
+}
+
+func GetLocker(client *redis.ClusterClient, key string, opts *Options) (*Locker, error) {
+	cmd := client.Get(key)
+	if cmd.Err() != nil {
+		return &Locker{}, cmd.Err()
+	}
+	token := cmd.Val()
+
+	locker := &Locker{
+		key:    key,
+		client: client,
+		token:  token,
+		opts:   *opts,
+	}
+
+	return locker, nil
+}


### PR DESCRIPTION
In our project we have following use cases:

In our project we have used instance_id as token prefix. Later, we want to get tokenPrefix so that we can tell which instance has locked a resource by getting that instance_id. Hence, I have added a getToken() method.

We want the ability to get locker object from lock key. So that we can getToken from that locker object.